### PR TITLE
Fix MakeGridFaceHistogram with empty meshes

### DIFF
--- a/framework/mesh/mesh_continuum/mesh_continuum.cc
+++ b/framework/mesh/mesh_continuum/mesh_continuum.cc
@@ -167,6 +167,13 @@ MeshContinuum::MakeGridFaceHistogram(double master_tolerance, double slave_toler
 
   std::stable_sort(face_size_histogram.begin(), face_size_histogram.end());
 
+  if (face_size_histogram.empty())
+  {
+    log.LogAllWarning() << "MeshContinuum::MakeGridFaceHistogram called on mesh "
+                        "with no faces.";
+    return std::make_shared<GridFaceHistogram>(face_categories_list);
+  }
+
   // Determine total face dofs
   size_t total_face_dofs_count = 0;
   for (auto face_size : face_size_histogram)

--- a/test/unit/framework/mesh/mesh_continuum_test.cc
+++ b/test/unit/framework/mesh/mesh_continuum_test.cc
@@ -204,3 +204,10 @@ TEST_F(MeshContinuumTest, PointInsideCellFace3D)
   const auto grid_ptr = BuildOrthogonalMesh({{-1.0, 1.0}, {0.0, 0.5, 1.0}, {-1.0, 0.0, 1.0}});
   TestPointInsideCellFace(grid_ptr);
 }
+
+TEST_F(MeshContinuumTest, EmptyFaceHistogram)
+{
+  auto grid_ptr = std::make_shared<MeshContinuum>();
+  ASSERT_NO_THROW({ auto hist = grid_ptr->MakeGridFaceHistogram();
+                    EXPECT_EQ(hist->GetNumberOfFaceHistogramBins(), 0u); });
+}


### PR DESCRIPTION
## Summary
- guard `MeshContinuum::MakeGridFaceHistogram` against empty mesh cases
- add unit test ensuring the histogram works with zero faces

## Testing
- `cmake -S . -B build` *(fails: Could NOT find MPI)*

------
https://chatgpt.com/codex/tasks/task_e_683f791177d08321ac82448e235c5b8b