### PR TITLE
Add warning for empty face histogram

### DIFF
--- a/framework/mesh/mesh_continuum/mesh_continuum.cc
+++ b/framework/mesh/mesh_continuum/mesh_continuum.cc
@@ -167,6 +167,13 @@ MeshContinuum::MakeGridFaceHistogram(double master_tolerance, double slave_toler
 
   std::stable_sort(face_size_histogram.begin(), face_size_histogram.end());
 
+  if (face_size_histogram.empty())
+  {
+    log.LogAllWarning() << "MeshContinuum::MakeGridFaceHistogram called on mesh "
+                           "with no faces.";
+    return std::make_shared<GridFaceHistogram>(face_categories_list);
+  }
+
   // Determine total face dofs
   size_t total_face_dofs_count = 0;
   for (auto face_size : face_size_histogram)


### PR DESCRIPTION
## Summary
- ensure `MakeGridFaceHistogram` handles meshes with no faces
- style-format affected code

## Testing
- `clang-format-14 -i framework/mesh/mesh_continuum/*.cc framework/mesh/mesh_continuum/*.h test/unit/framework/mesh/mesh_continuum_test.cc`
- `clang-format-14 -n --Werror framework/mesh/mesh_continuum/*.cc framework/mesh/mesh_continuum/*.h test/unit/framework/mesh/mesh_continuum_test.cc`


------
https://chatgpt.com/codex/tasks/task_e_683f819eb3188321991f1bc5db19b883