### PR TITLE
Add Doxygen comments in MultiGroupXS header

### DIFF
--- a/framework/materials/multi_group_xs/multi_group_xs.h
+++ b/framework/materials/multi_group_xs/multi_group_xs.h
@@ -8,9 +8,11 @@
 namespace opensn
 {
 
+/// Multi-group cross section container.
 class MultiGroupXS : public std::enable_shared_from_this<MultiGroupXS>
 {
 public:
+  /// Default constructor.
   MultiGroupXS()
     : num_groups_(0),
       scattering_order_(0),
@@ -22,20 +24,39 @@ public:
   {
   }
 
-  /// Makes a simple material with a 1-group cross-section set.
+  /**
+   * Makes a simple material with a 1-group cross-section set.
+   *
+   * \param sigma_t Total cross section.
+   * \param c Scattering ratio.
+   */
   void Initialize(double sigma_t, double c);
 
-  /// Populates the cross section from a combination of others.
+  /**
+   * Populates the cross section from a combination of others.
+   *
+   * \param combinations Pairs of cross-section handles and scaling factors.
+   */
   void Initialize(std::vector<std::pair<int, double>>& combinations);
 
-  /// This method populates transport cross sections from an OpenSn cross-section file.
+  /**
+   * Populates transport cross sections from an OpenSn cross-section file.
+   *
+   * \param file_name Path to the OpenSn cross section file.
+   */
   void Initialize(const std::string& file_name);
 
-  /// This method populates transport cross sections from an OpenMC cross-section file.
+  /**
+   * Populates transport cross sections from an OpenMC cross-section file.
+   *
+   * \param file_name Path to the HDF5 file.
+   * \param dataset_name Dataset inside the file.
+   * \param temperature Temperature in Kelvin.
+   */
   void
   Initialize(const std::string& file_name, const std::string& dataset_name, double temperature);
 
-  /// A struct containing data for a delayed neutron precursor.
+  /// Data for a delayed neutron precursor.
   struct Precursor
   {
     double decay_constant = 0.0;
@@ -61,14 +82,19 @@ public:
    */
   void ExportToOpenSnXSFile(const std::string& file_name, const double fission_scaling = 1.0) const;
 
+  /// Returns the number of energy groups.
   size_t GetNumGroups() const { return num_groups_; }
 
+  /// Returns the scattering order.
   size_t GetScatteringOrder() const { return scattering_order_; }
 
+  /// Returns the number of precursor families.
   size_t GetNumPrecursors() const { return num_precursors_; }
 
+  /// Indicates if the material is fissionable.
   bool IsFissionable() const { return is_fissionable_; }
 
+  /// Enable or disable adjoint mode.
   void SetAdjointMode(bool val)
   {
     adjoint_ = val;
@@ -76,51 +102,70 @@ public:
       TransposeTransferAndProduction();
   }
 
+  /// Returns true if adjoint mode is enabled.
   bool GetAdjointMode() const { return adjoint_; }
 
+  /// Current scaling factor applied to the data.
   double GetScalingFactor() const { return scaling_factor_; }
 
+  /// Total cross section per group.
   const std::vector<double>& GetSigmaTotal() const { return sigma_t_; }
 
+  /// Absorption cross section per group.
   const std::vector<double>& GetSigmaAbsorption() const { return sigma_a_; }
 
+  /// Transfer matrices ordered by scattering moment.
   const std::vector<SparseMatrix>& GetTransferMatrices() const
   {
     return adjoint_ ? transposed_transfer_matrices_ : transfer_matrices_;
   }
 
+  /// Transfer matrix for a specific scattering moment.
   const SparseMatrix& GetTransferMatrix(unsigned int ell) const
   {
     return adjoint_ ? transposed_transfer_matrices_.at(ell) : transfer_matrices_.at(ell);
   }
 
+  /// Fission spectrum.
   const std::vector<double>& GetChi() const { return chi_; }
 
+  /// Fission cross section per group.
   const std::vector<double>& GetSigmaFission() const { return sigma_f_; }
 
+  /// Neutron production cross section.
   const std::vector<double>& GetNuSigmaF() const { return nu_sigma_f_; }
 
+  /// Prompt neutron production cross section.
   const std::vector<double>& GetNuPromptSigmaF() const { return nu_prompt_sigma_f_; }
 
+  /// Delayed neutron production cross section.
   const std::vector<double>& GetNuDelayedSigmaF() const { return nu_delayed_sigma_f_; }
 
+  /// Total neutron production matrix.
   const std::vector<std::vector<double>>& GetProductionMatrix() const
   {
     return adjoint_ ? transposed_production_matrix_ : production_matrix_;
   }
 
+  /// Delayed neutron precursor data.
   const std::vector<Precursor>& GetPrecursors() const { return precursors_; }
 
+  /// Inverse neutron velocities.
   const std::vector<double>& GetInverseVelocity() const { return inv_velocity_; }
 
+  /// Indicates if diffusion data have been initialized.
   bool DiffusionInitialized() const { return diffusion_initialized_; }
 
+  /// Transport cross section per group.
   const std::vector<double>& GetSigmaTransport() const { return sigma_tr_; }
 
+  /// Diffusion coefficient per group.
   const std::vector<double>& GetDiffusionCoefficient() const { return diffusion_coeff_; }
 
+  /// Removal cross section per group.
   const std::vector<double>& GetSigmaRemoval() const { return sigma_r_; }
 
+  /// Within-group scattering cross section per group.
   const std::vector<double>& GetSigmaSGtoG() const { return sigma_s_gtog_; }
 
 private:
@@ -175,12 +220,16 @@ private:
   /// Within-group scattering cross section
   std::vector<double> sigma_s_gtog_;
 
+  /// Resets all data to the uninitialized state.
   void Reset();
 
+  /// Computes absorption from the total and scattering matrices.
   void ComputeAbsorption();
 
+  /// Computes various diffusion-related quantities.
   void ComputeDiffusionParameters();
 
+  /// Populates transposed transfer and production matrices.
   void TransposeTransferAndProduction();
 
   /// Check vector for all non-negative values


### PR DESCRIPTION
## Summary
- document `MultiGroupXS` class and its API using Doxygen markers
- clarify getters and helper methods

## Testing
- `./test/run_tests` *(fails: ModuleNotFoundError: No module named 'nbconvert')*

------
https://chatgpt.com/codex/tasks/task_e_683f8be0420483219f39cb412aec8e82