### PR TITLE
Add Doxygen headers

### DIFF
--- a/framework/data_types/allowable_range.h
+++ b/framework/data_types/allowable_range.h
@@ -10,6 +10,11 @@
 #include <algorithm>
 #include <sstream>
 
+/**
+ * \file
+ * Utilities for expressing allowable value ranges used by BasicOptions
+ * and other validation mechanisms.
+ */
 namespace opensn
 {
 

--- a/framework/data_types/basic_options.h
+++ b/framework/data_types/basic_options.h
@@ -5,6 +5,10 @@
 
 #include "framework/data_types/varying.h"
 
+/**
+ * \file
+ * Defines light-weight containers for storing named configuration values.
+ */
 namespace opensn
 {
 

--- a/framework/data_types/byte_array.h
+++ b/framework/data_types/byte_array.h
@@ -9,6 +9,10 @@
 #include <cstring>
 #include <cstddef>
 
+/**
+ * \file
+ * Container providing utilities for reading and writing raw bytes.
+ */
 namespace opensn
 {
 

--- a/framework/data_types/data_types.h
+++ b/framework/data_types/data_types.h
@@ -5,6 +5,11 @@
 
 #include <string>
 
+/**
+ * \file
+ * Enumerations and helper utilities describing data types that can be
+ * stored inside a Varying object.
+ */
 namespace opensn
 {
 

--- a/framework/data_types/ndarray.h
+++ b/framework/data_types/ndarray.h
@@ -15,6 +15,11 @@
 #include <vector>
 #include <string>
 
+/**
+ * \file
+ * Lightweight multidimensional array supporting bounds checking and
+ * value initialization utilities.
+ */
 namespace opensn
 {
 

--- a/framework/data_types/varying.h
+++ b/framework/data_types/varying.h
@@ -12,6 +12,11 @@
 #include <vector>
 #include <memory>
 
+/**
+ * \file
+ * Implements the Varying class, a type-erased container capable of
+ * holding strings, numbers, and user data.
+ */
 namespace opensn
 {
 


### PR DESCRIPTION
## Summary
- document framework/data_types headers with Doxygen file comments

## Testing
- `python3 test/run_tests --exe /nonexistent` *(fails: FileNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_683f93b6ece483218453e0bb3c876ae2